### PR TITLE
perf(apps/api): vault service bindings

### DIFF
--- a/apps/api/src/lib/enviroment/index.ts
+++ b/apps/api/src/lib/enviroment/index.ts
@@ -1,3 +1,4 @@
+import type {Fetcher} from '@cloudflare/workers-types';
 import project from '../../../package.json';
 import {z} from 'zod';
 
@@ -13,6 +14,7 @@ export const zEnv = z.object({
 
   //Cloudflare Bindings
   cache: z.custom<KVNamespace>(),
+  vault: z.custom<Fetcher>(),
 
   // Databases
   DATABASE_URL: z.string().url().default('http://localhost:8080'),

--- a/apps/api/src/lib/services/middleware.ts
+++ b/apps/api/src/lib/services/middleware.ts
@@ -59,7 +59,8 @@ export function services(): MiddlewareHandler<HonoEnv> {
     const vault = new Vault({
       url: c.env.VAULT_URL,
       token: c.env.VAULT_SECRET,
-      serviceBinding: c.env.ENVIROMENT === 'development' ? undefined : c.env.vault
+      serviceBinding:
+        c.env.ENVIROMENT === 'development' ? undefined : c.env.vault
     });
 
     const email = new Resend(

--- a/apps/api/src/lib/services/middleware.ts
+++ b/apps/api/src/lib/services/middleware.ts
@@ -58,7 +58,8 @@ export function services(): MiddlewareHandler<HonoEnv> {
 
     const vault = new Vault({
       url: c.env.VAULT_URL,
-      token: c.env.VAULT_SECRET
+      token: c.env.VAULT_SECRET,
+      serviceBinding: c.env.vault
     });
 
     const email = new Resend(

--- a/apps/api/src/lib/services/middleware.ts
+++ b/apps/api/src/lib/services/middleware.ts
@@ -59,7 +59,7 @@ export function services(): MiddlewareHandler<HonoEnv> {
     const vault = new Vault({
       url: c.env.VAULT_URL,
       token: c.env.VAULT_SECRET,
-      serviceBinding: c.env.vault
+      serviceBinding: c.env.ENVIROMENT === 'development' ? undefined : c.env.vault
     });
 
     const email = new Resend(

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -2,6 +2,7 @@ name = "api"
 main = "src/index.ts"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
+services = [ {binding = "vault", service = "vault"}]
 
 [placement]
 mode = "smart"
@@ -18,6 +19,7 @@ preview_id = "20acddf9715c4701b923250853fccf39"
 [env.development]
 name = "api-development"
 vars = { ENVIROMENT = "development" }
+services = [ {binding = "vault", service = "vault-development"}]
 routes = [ { pattern = "api-development.formizee.com", custom_domain = true } ]
 
 [vars]
@@ -31,6 +33,7 @@ DASHBOARD_URL="http://localhost:3001"
 
 [env.preview]
 name = "api-preview"
+services = [ {binding = "vault", service = "vault-preview"}]
 routes = [ { pattern = "api-preview.formizee.com", custom_domain = true } ]
 kv_namespaces = [{ binding = "cache", id = "20acddf9715c4701b923250853fccf39" }]
 
@@ -45,6 +48,7 @@ DASHBOARD_URL="https://dashboard.formizee.com"
 
 [env.production]
 name = "api-production"
+services = [ {binding = "vault", service = "vault-production"}]
 routes = [ { pattern = "api.formizee.com", custom_domain = true } ]
 kv_namespaces = [{ binding = "cache", id = "5afb50fb9774441e8fc927078e274790" }]
 

--- a/internal/vault/package.json
+++ b/internal/vault/package.json
@@ -10,6 +10,7 @@
     "check": "tsc --noEmit"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "4.20250109.0",
     "@formizee/tsconfig": "workspace:*",
     "@types/node": "22.0.0"
   },

--- a/internal/vault/src/endpoints/index.ts
+++ b/internal/vault/src/endpoints/index.ts
@@ -1,19 +1,22 @@
 import type {DeleteRequest, DeleteResponse} from './types';
 import type {StatusCode, VaultOptions} from '../types';
+import {FetchWrapper} from '../fetcher';
 
 export class Endpoints {
   private readonly url: string;
   private readonly token: string;
+  private readonly service: FetchWrapper;
 
   constructor(opts: VaultOptions) {
     this.url = opts.url;
     this.token = opts.token;
+    this.service = new FetchWrapper(opts.serviceBinding);
   }
 
   public async delete(input: DeleteRequest): Promise<DeleteResponse> {
     const url = `${this.url}/v1/endpoint/${input.endpointId}`;
 
-    const response = await fetch(url, {
+    const response = await this.service.fetch(url, {
       headers: {Authorization: `Bearer ${this.token}`},
       method: 'DELETE'
     });

--- a/internal/vault/src/fetcher.ts
+++ b/internal/vault/src/fetcher.ts
@@ -1,4 +1,4 @@
-import {Fetcher} from '@cloudflare/workers-types';
+import type {Fetcher} from '@cloudflare/workers-types';
 
 export class FetchWrapper {
   private readonly fetcher: Fetcher | null;

--- a/internal/vault/src/fetcher.ts
+++ b/internal/vault/src/fetcher.ts
@@ -1,0 +1,18 @@
+import {Fetcher} from '@cloudflare/workers-types';
+
+export class FetchWrapper {
+  private readonly fetcher: Fetcher | null;
+
+  constructor(fetcher: Fetcher | null = null) {
+    this.fetcher = fetcher; // Assign the custom fetcher if provided
+  }
+
+  async fetch(url: string, options = {}) {
+    // Use fetcher if provided, otherwise fallback to the default fetch API
+    if (this.fetcher) {
+      return this.fetcher.fetch(url, options);
+    }
+
+    return fetch(url, options);
+  }
+}

--- a/internal/vault/src/storage/index.ts
+++ b/internal/vault/src/storage/index.ts
@@ -1,19 +1,22 @@
 import type {GetRequest, GetResponse, PostRequest, PostResponse} from './types';
 import type {StatusCode, VaultOptions} from '../types';
+import {FetchWrapper} from '../fetcher';
 
 export class Storage {
   private readonly url: string;
   private readonly token: string;
+  private readonly service: FetchWrapper;
 
   constructor(opts: VaultOptions) {
     this.url = opts.url;
     this.token = opts.token;
+    this.service = new FetchWrapper(opts.serviceBinding);
   }
 
   public async get(input: GetRequest): Promise<GetResponse> {
     const url = `${this.url}/v1/storage/${input.endpointId}`;
 
-    const response = await fetch(url, {
+    const response = await this.service.fetch(url, {
       headers: {Authorization: `Bearer ${this.token}`},
       method: 'GET'
     });
@@ -45,7 +48,7 @@ export class Storage {
   public async post(input: PostRequest): Promise<PostResponse> {
     const url = `${this.url}/v1/storage/${input.endpointId}`;
 
-    const response = await fetch(url, {
+    const response = await this.service.fetch(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.token}`,

--- a/internal/vault/src/submissions/index.ts
+++ b/internal/vault/src/submissions/index.ts
@@ -1,4 +1,5 @@
 import type {StatusCode, VaultOptions} from '../types';
+import {FetchWrapper} from '../fetcher';
 
 import type {
   DeleteRequest,
@@ -20,16 +21,18 @@ import type {
 export class Submissions {
   private readonly url: string;
   private readonly token: string;
+  private readonly service: FetchWrapper;
 
   constructor(opts: VaultOptions) {
     this.url = opts.url;
     this.token = opts.token;
+    this.service = new FetchWrapper(opts.serviceBinding);
   }
 
   public async get(input: GetRequest): Promise<GetResponse> {
     const url = `${this.url}/v1/submission/${input.endpointId}/${input.id}`;
 
-    const response = await fetch(url, {
+    const response = await this.service.fetch(url, {
       headers: {Authorization: `Bearer ${this.token}`},
       method: 'GET'
     });
@@ -68,7 +71,7 @@ export class Submissions {
       queryUrl.searchParams.append('limit', String(input.limit));
     }
 
-    const response = await fetch(queryUrl, {
+    const response = await this.service.fetch(queryUrl.toString(), {
       headers: {Authorization: `Bearer ${this.token}`},
       method: 'GET'
     });
@@ -100,7 +103,7 @@ export class Submissions {
   public async post(input: PostRequest): Promise<PostResponse> {
     const url = `${this.url}/v1/submission`;
 
-    const response = await fetch(url, {
+    const response = await this.service.fetch(url, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.token}`,
@@ -136,7 +139,7 @@ export class Submissions {
   public async put(input: PutRequest): Promise<PutResponse> {
     const url = `${this.url}/v1/submission/${input.endpointId}/${input.id}`;
 
-    const response = await fetch(url, {
+    const response = await this.service.fetch(url, {
       headers: {
         Authorization: `Bearer ${this.token}`,
         'Content-Type': 'application/json'
@@ -172,7 +175,7 @@ export class Submissions {
   public async delete(input: DeleteRequest): Promise<DeleteResponse> {
     const url = `${this.url}/v1/submission/${input.endpointId}/${input.id}`;
 
-    const response = await fetch(url, {
+    const response = await this.service.fetch(url, {
       headers: {Authorization: `Bearer ${this.token}`},
       method: 'DELETE'
     });

--- a/internal/vault/src/types.ts
+++ b/internal/vault/src/types.ts
@@ -1,9 +1,11 @@
+import type {Fetcher} from '@cloudflare/workers-types';
 import type {StatusCode} from './http-status';
 export type {StatusCode};
 
 export interface VaultOptions {
   url: string;
   token: string;
+  serviceBinding?: Fetcher;
 }
 
 export interface ErrorResponse {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -892,6 +892,9 @@ importers:
         specifier: workspace:*
         version: link:../db
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 4.20250109.0
+        version: 4.20250109.0
       '@formizee/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -1205,6 +1208,9 @@ packages:
 
   '@cloudflare/workers-types@4.20241127.0':
     resolution: {integrity: sha512-UqlvtqV8eI0CdPR7nxlbVlE52+lcjHvGdbYXEPwisy23+39RsFV7OOy0da0moJAhqnL2OhDmWTOaKdsVcPHiJQ==}
+
+  '@cloudflare/workers-types@4.20250109.0':
+    resolution: {integrity: sha512-Y1zgSaEOOevl9ORpzgMcm4j535p3nK2lrblHHvYM2yxR50SBKGh+wvkRFAIxWRfjUGZEU+Fp6923EGioDBbobA==}
 
   '@commitlint/cli@19.3.0':
     resolution: {integrity: sha512-LgYWOwuDR7BSTQ9OLZ12m7F/qhNY+NpAyPBgo4YNMkACE7lGuUnuQq1yi9hz1KA4+3VqpOYl8H1rY/LYK43v7g==}
@@ -8423,6 +8429,8 @@ snapshots:
   '@cloudflare/workers-types@4.20241022.0': {}
 
   '@cloudflare/workers-types@4.20241127.0': {}
+
+  '@cloudflare/workers-types@4.20250109.0': {}
 
   '@commitlint/cli@19.3.0(@types/node@22.10.2)(typescript@5.4.5)':
     dependencies:


### PR DESCRIPTION
This PR updates the @formizee/vault to add the option of using Cloudflare service bindings in order to improve latency when running request against the vault service